### PR TITLE
feat(shard): adding capability to add a shard identifier [CU-8x8uvt7f5]

### DIFF
--- a/API.md
+++ b/API.md
@@ -485,6 +485,7 @@ new Shard(props: IShardProps)
 | <code><a href="#@time-loop/cdk-named-environments.Shard.property.name">name</a></code> | <code>string</code> | There are numerous different ways to name a shard. |
 | <code><a href="#@time-loop/cdk-named-environments.Shard.property.number">number</a></code> | <code>number</code> | The shard-number within the region. |
 | <code><a href="#@time-loop/cdk-named-environments.Shard.property.region">region</a></code> | <code>string</code> | The AWS region for a shard. |
+| <code><a href="#@time-loop/cdk-named-environments.Shard.property.identifier">identifier</a></code> | <code>string</code> | The shard-identifier. |
 
 ---
 
@@ -539,6 +540,18 @@ The AWS region for a shard.
 
 ---
 
+##### `identifier`<sup>Optional</sup> <a name="identifier" id="@time-loop/cdk-named-environments.Shard.property.identifier"></a>
+
+```typescript
+public readonly identifier: string;
+```
+
+- *Type:* string
+
+The shard-identifier.
+
+---
+
 
 ## Protocols <a name="Protocols" id="Protocols"></a>
 
@@ -556,6 +569,7 @@ The AWS region for a shard.
 | <code><a href="#@time-loop/cdk-named-environments.IShard.property.cidr">cidr</a></code> | <code>string</code> | The CIDR block for a shard. |
 | <code><a href="#@time-loop/cdk-named-environments.IShard.property.number">number</a></code> | <code>number</code> | The shard-number within the region. |
 | <code><a href="#@time-loop/cdk-named-environments.IShard.property.region">region</a></code> | <code>string</code> | The AWS region for a shard. |
+| <code><a href="#@time-loop/cdk-named-environments.IShard.property.identifier">identifier</a></code> | <code>string</code> | The shard-identifier. |
 | <code><a href="#@time-loop/cdk-named-environments.IShard.property.name">name</a></code> | <code>string</code> | The proper name for a shard (without numeric suffix). |
 
 ---
@@ -596,6 +610,18 @@ The AWS region for a shard.
 
 ---
 
+##### `identifier`<sup>Optional</sup> <a name="identifier" id="@time-loop/cdk-named-environments.IShard.property.identifier"></a>
+
+```typescript
+public readonly identifier: string;
+```
+
+- *Type:* string
+
+The shard-identifier.
+
+---
+
 ##### `name`<sup>Required</sup> <a name="name" id="@time-loop/cdk-named-environments.IShard.property.name"></a>
 
 ```typescript
@@ -620,6 +646,7 @@ The proper name for a shard (without numeric suffix).
 | <code><a href="#@time-loop/cdk-named-environments.IShardProps.property.cidr">cidr</a></code> | <code>string</code> | The CIDR block for a shard. |
 | <code><a href="#@time-loop/cdk-named-environments.IShardProps.property.number">number</a></code> | <code>number</code> | The shard-number within the region. |
 | <code><a href="#@time-loop/cdk-named-environments.IShardProps.property.region">region</a></code> | <code>string</code> | The AWS region for a shard. |
+| <code><a href="#@time-loop/cdk-named-environments.IShardProps.property.identifier">identifier</a></code> | <code>string</code> | The shard-identifier. |
 
 ---
 
@@ -656,6 +683,18 @@ public readonly region: string;
 - *Type:* string
 
 The AWS region for a shard.
+
+---
+
+##### `identifier`<sup>Optional</sup> <a name="identifier" id="@time-loop/cdk-named-environments.IShardProps.property.identifier"></a>
+
+```typescript
+public readonly identifier: string;
+```
+
+- *Type:* string
+
+The shard-identifier.
 
 ---
 

--- a/src/Shard.ts
+++ b/src/Shard.ts
@@ -11,6 +11,10 @@ export interface IShardProps {
    * The shard-number within the region.
    */
   readonly number: number;
+  /**
+   * The shard-identifier.
+   */
+  readonly identifier?: string;
 }
 
 export interface IShard extends IShardProps {
@@ -24,11 +28,13 @@ export abstract class Shard implements IShard {
   readonly cidr: string;
   readonly region: string;
   readonly number: number;
+  readonly identifier: string | undefined;
 
   constructor(props: IShardProps) {
     this.cidr = props.cidr;
     this.region = props.region;
     this.number = props.number;
+    this.identifier = props.identifier;
   }
 
   /**

--- a/test/Shard.test.ts
+++ b/test/Shard.test.ts
@@ -3,28 +3,58 @@ import { IShard, Shard, IShardProps } from '../src';
 const env = 'QA';
 class TestShardImpl extends Shard {
   get name(): string {
-    return `${env}_${this.region}_${this.number}`;
+    const suffix = this.identifier ?? this.number;
+    return `${env}_${this.region}_${suffix}`;
   }
 }
 
-const testShardProps: IShardProps = { cidr: 'fakeCidr', region: 'us-west-2', number: 1 };
+interface TestCase {
+  shardsProps: IShardProps;
+  expectedShardName: string;
+  isShardIdentifierUndefined?: boolean;
+}
+const testCases: TestCase[] = [
+  {
+    shardsProps: { cidr: 'fakeCidr', region: 'us-west-2', number: 1 },
+    expectedShardName: 'QA_us-west-2_1',
+    isShardIdentifierUndefined: true,
+  },
+  {
+    shardsProps: { cidr: 'fakeCidr', region: 'us-east-2', number: 1, identifier: 'global' },
+    expectedShardName: 'QA_us-east-2_global',
+    isShardIdentifierUndefined: false,
+  },
+];
 
-let shard: IShard;
-describe('Shard', () => {
-  beforeEach(() => {
-    shard = new TestShardImpl(testShardProps);
-  });
+describe.each<TestCase>(testCases)(
+  'Shard implementation: $expectedShardName',
+  ({ shardsProps, expectedShardName, isShardIdentifierUndefined }) => {
+    let shard: IShard;
 
-  it('sets cidr correctly', () => {
-    expect(shard.cidr).toEqual(testShardProps.cidr);
-  });
-  it('sets region correctly', () => {
-    expect(shard.region).toEqual(testShardProps.region);
-  });
-  it('sets number correctly', () => {
-    expect(shard.number).toEqual(testShardProps.number);
-  });
-  it('sets name correctly', () => {
-    expect(shard.name).toEqual('QA_us-west-2_1');
-  });
-});
+    beforeEach(() => {
+      shard = new TestShardImpl(shardsProps);
+    });
+
+    it('sets cidr correctly', () => {
+      expect(shard.cidr).toEqual(shardsProps.cidr);
+    });
+    it('sets region correctly', () => {
+      expect(shard.region).toEqual(shardsProps.region);
+    });
+    it('sets number correctly', () => {
+      expect(shard.number).toEqual(shardsProps.number);
+    });
+    it('sets name correctly', () => {
+      expect(shard.name).toEqual(expectedShardName);
+    });
+    if (isShardIdentifierUndefined) {
+      it('identifier is undefined', () => {
+        expect(shard.identifier).toBeUndefined();
+      });
+    } else {
+      it('sets identifier correctly', () => {
+        expect(shard.identifier).toEqual(shardsProps.identifier);
+      });
+    }
+  },
+);


### PR DESCRIPTION
# Summary
adding the capability to add a shard identifier is required to deploy the new global shards.
**Related task** [8x8uvt7f5](https://staging.clickup.com/t/8x8uvt7f5)
